### PR TITLE
Refactor mutate request, change initialization handshake

### DIFF
--- a/docs/mutation-server-protocol.md
+++ b/docs/mutation-server-protocol.md
@@ -210,7 +210,7 @@ interface ProgressParams<T> {
 Progress is reported against a token. The token is different than the request ID which allows to report progress out of band and also for notification.
 
 #### Partial Result Progress
-Partial results are also reported using the generic progress notification. The value payload of a partial result progress notification should be the same as the final result. For example the mutate request has `MutantResult[]` as the result type. Partial result is therefore also of type `MutantResult[]`. Whether a client accepts partial result notifications for a request is signaled by adding a partialResultToken to the request parameter. For example, a mutate request that supports partial result progress might look like this:
+Partial results are also reported using the generic progress notification. The value payload of a partial result progress notification should be the same as the final result. For example the mutation test request has `MutantResult[]` as the result type. Partial result is therefore also of type `MutantResult[]`. Whether a client accepts partial result notifications for a request is signaled by adding a partialResultToken to the request parameter. For example, a mutationTest request that supports partial result progress might look like this:
 
 ```json
 {
@@ -363,12 +363,12 @@ The protocol also uses versioning to manage changes. Both the client and the ser
 ## Mutation Server Protocol
 The language server protocol defines a set of JSON-RPC request, response and notification messages which are exchanged using the above base protocol. This section starts describing the basic JSON structures used in the protocol. The document uses TypeScript interfaces to describe these. Based on the basic JSON structures, the actual requests with their responses and the notifications are described.
 
-An example would be a request send from the client to the server to request a mutation test run for specific glob patterns. The request's method would be 'mutate' with a parameter like this:
+An example would be a request send from the client to the server to request a mutation test run for specific glob patterns. The request's method would be 'mutationTest' with a parameter like this:
 
 ```typescript
-interface MutateParams extends PartialResultParams {
+interface MutationTestParams extends PartialResultParams {
   /**
-   * The glob patterns to mutate.
+   * The glob patterns to mutation test.
    */
   globPatterns?: string[];
 }
@@ -376,7 +376,7 @@ interface MutateParams extends PartialResultParams {
 
 The result of the request would be an array of mutants which have been tested. So the result looks like this:
 ```typescript
-interface MutateResult {
+interface MutationTestResult {
 	value: MutantResult[];
 }
 ```
@@ -389,13 +389,13 @@ Please also note that a response return value of null indicates no result. It do
 The request is sent from the client to the server to start a mutation run for the given glob patterns.
 
 Request:
-* method: 'mutate'
-* params: `MutateParams` defined as follows:
+* method: 'mutationTest'
+* params: `MutationTestParams` defined as follows:
 
 ```typescript
-interface MutateParams extends PartialResultParams {
+interface MutationTestParams extends PartialResultParams {
   /**
-   * The glob patterns to mutate.
+   * The glob patterns to mutation test.
    */
   globPatterns?: string[];
 }
@@ -500,7 +500,7 @@ interface Position {
 ```
 
 * partial result: [`MutantResult[]`](#mutantresult)
-* error: code and message set in case an exception happens during the ‘mutate’ request
+* error: code and message set in case an exception happens during the ‘mutationTest’ request
 
 ### Instrument run
 The request is sent from the client to the server to request mutations for the given glob patterns.

--- a/docs/mutation-server-protocol.md
+++ b/docs/mutation-server-protocol.md
@@ -26,13 +26,22 @@ Table of contents:
 ## Overview
 The idea behind a *Mutation Server* is to provide mutation-specific smarts inside a server that can communicate with development tooling (such as an IDE) over a protocol that enables inter-process communication.
 
-The idea behind the *Mutation Server Protocol* is to standardize the protocol for how tools and servers communicate, so a single *Mutation Server* can be re-used in multiple development tools, and tools can support mutation testing frameworks with minimal effort. A mutation server runs as a separate process and development tools communicate with the server using the mutation server protocol over JSON-RPC.
+The idea behind the *Mutation Server Protocol* is to standardize the protocol for how tools and servers communicate, so a single *Mutation Server* can be re-used in multiple development tools, and tools can support mutation testing frameworks with minimal effort. A mutation server runs as a separate process and development tools communicate with the server using the mutation server protocol over JSON-RPC via a WebSocket connection.
 
 The *Mutation Server Protocol* is inspired by the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/)
 
 ## Base Protocol
 
-The base protocol sends JSON-RPC 2.0 messages using HTTP transport protocol. 
+The base protocol exchanges JSON-RPC 2.0 messages between the client and the server in a bi-directional manner using a WebSocket connection for message transportation.
+
+The mutation server must:
+
+1. Provide the WebSocket server.
+2. Once the WebSocket server is ready for connections, output the server port as the first message to the standard output in the following regex format: `/Server is listening on port: (\d+)/.`
+
+The client must listen for this output message and, upon receiving it, connect to the WebSocket server using the specified port.
+
+*In the future, the protocol may support additional inter-process communication (IPC) methods, such as standard input/output (stdio), pipes, and sockets.*
 
 ### Abstract Message
 A general message as defined by JSON-RPC. The mutation server protocol always uses “2.0” as the jsonrpc version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stryker-mutator",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stryker-mutator",
-      "version": "0.0.1",
+      "version": "0.0.1-alpha.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "json-rpc-2.0": "^1.7.0",
@@ -250,20 +250,20 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.2.0.tgz",
-      "integrity": "sha512-ve3aYv79qXOJ8wRxQ5jO0eIz2DZ4o0TyME4m4vlGV5YyePddVZ+pFMzusAMODNAflYAAv1cBIhKnd4xytmXyig==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.3.0.tgz",
+      "integrity": "sha512-LHZ58/RsIpIWa4hrrE2YuJ/vzG1Jv9f774RfTTAVDZDriubvJ0/S5u4pnw4akJDlS0TiJb6VMphmVUFsWmgodQ==",
       "dev": true,
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.5.0",
-        "@azure/core-client": "^1.4.0",
+        "@azure/core-client": "^1.9.2",
         "@azure/core-rest-pipeline": "^1.1.0",
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.3.0",
         "@azure/logger": "^1.0.0",
         "@azure/msal-browser": "^3.11.1",
-        "@azure/msal-node": "^2.6.6",
+        "@azure/msal-node": "^2.9.2",
         "events": "^3.0.0",
         "jws": "^4.0.0",
         "open": "^8.0.0",
@@ -308,17 +308,26 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.7.0.tgz",
-      "integrity": "sha512-wXD8LkUvHICeSWZydqg6o8Yvv+grlBEcmLGu+QEI4FcwFendbTEZrlSygnAXXSOCVaGAirWLchca35qrgpO6Jw==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.9.2.tgz",
+      "integrity": "sha512-8tvi6Cos3m+0KmRbPjgkySXi+UQU/QiuVRFnrxIwt5xZlEEFa69O04RTaNESGgImyBBlYbo2mfE8/U8Bbdk1WQ==",
       "dev": true,
       "dependencies": {
-        "@azure/msal-common": "14.9.0",
+        "@azure/msal-common": "14.12.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "14.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.12.0.tgz",
+      "integrity": "sha512-IDDXmzfdwmDkv4SSmMEyAniJf6fDu3FJ7ncOjlxkDuT85uSnLEhZi3fGZpoR7T4XZpOMx9teM9GXBgrfJgyeBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node/node_modules/uuid": {
@@ -2794,12 +2803,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4494,9 +4503,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -9175,9 +9184,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Stryker Mutator",
   "publisher": "stryker-mutator",
   "description": "Test your tests with Stryker mutation testing.",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.1",
   "engines": {
     "vscode": "^1.86.0"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export interface Config {
     fileChangeDebounceTimeMs: number;
     defaultWindowsExecutablePath: string;
     defaultUnixExecutablePath: string;
+    protocolVersion: string;
   };
   messages: {
     instrumentationRunning: string;
@@ -26,6 +27,7 @@ export const config: Config = {
     fileChangeDebounceTimeMs: 250,
     defaultWindowsExecutablePath: '.\\node_modules\\.bin\\stryker-server.cmd',
     defaultUnixExecutablePath: './node_modules/.bin/stryker-server',
+    protocolVersion: '0.0.1-alpha.1',
   },
   messages: {
     instrumentationRunning: 'Running instrumentation',

--- a/src/handlers/test-run-handler.ts
+++ b/src/handlers/test-run-handler.ts
@@ -6,7 +6,7 @@ import { v4 as uuid } from 'uuid';
 import { config } from '../config';
 import { pathUtils } from '../utils/path-utils';
 import { MutantResult } from '../api/mutant-result';
-import { MutateParams } from '../mutation-server/mutation-server-protocol';
+import { MutationTestParams } from '../mutation-server/mutation-server-protocol';
 import { MutationServer } from '../mutation-server/mutation-server';
 import { Logger } from '../utils/logger';
 
@@ -45,13 +45,13 @@ export class TestRunHandler {
     });
 
     try {
-      const mutateParams: MutateParams = {
+      const mutationTestParams: MutationTestParams = {
         globPatterns: globPatterns,
         partialResultToken: uuid(),
       };
 
-      await this.protocolHandler.mutate(
-        mutateParams,
+      await this.protocolHandler.mutationTest(
+        mutationTestParams,
         async (partialResult) => {
           await this.handleResult(partialResult.mutants, run);
         },

--- a/src/mutation-server/mutation-server-factory.ts
+++ b/src/mutation-server/mutation-server-factory.ts
@@ -27,11 +27,12 @@ export class MutationServerFactory {
     const workspaceFolderConfig = vscode.workspace.getConfiguration(config.app.name, workspaceFolder);
     const configUri: string | undefined = workspaceFolderConfig.get('configFilePathOverwrite');
 
-    const initializeParams: InitializeParams = {};
-
-    if (configUri && configUri.length > 0) {
-      initializeParams.configUri = configUri;
-    }
+    const initializeParams: InitializeParams = {
+      clientInfo: {
+        version: config.app.protocolVersion,
+      },
+      ...(configUri && configUri.length > 0 ? { configUri } : {}),
+    };
 
     await server.initialize(initializeParams);
 

--- a/src/mutation-server/mutation-server-protocol.ts
+++ b/src/mutation-server/mutation-server-protocol.ts
@@ -35,6 +35,8 @@ type MutationTestOptions = PartialResultOptions;
 
 /**
  * The capabilities provided by the server.
+ * For future compatibility this object can have more properties set than currently defined.
+ * Clients receiving this object with unknown properties should ignore these properties. A missing property should be interpreted as an absence of the capability.
  */
 export interface ServerCapabilities {
   /**

--- a/src/mutation-server/mutation-server-protocol.ts
+++ b/src/mutation-server/mutation-server-protocol.ts
@@ -2,12 +2,67 @@ import { MutantResult } from '../api/mutant-result';
 
 export interface InitializeParams {
   /**
+   * Information about the client.
+   */
+  clientInfo: {
+    /**
+     * The client's version as defined by the client.
+     */
+    version: string;
+  };
+  /**
    * The URI of the mutation testing framework config file
    */
   configUri?: string;
 }
 
-const InitializeResult = {};
+export interface PartialResultOptions {
+  /**
+   * The server supports returning partial results.
+   */
+  partialResults?: boolean;
+}
+
+/**
+ * The options for instrumentation provider.
+ */
+type InstrumentationOptions = PartialResultOptions;
+
+/**
+ * The options for mutation testing provider.
+ */
+type MutationTestOptions = PartialResultOptions;
+
+/**
+ * The capabilities provided by the server.
+ */
+export interface ServerCapabilities {
+  /**
+   * The server provides support for instrument runs.
+   */
+  instrumentationProvider?: InstrumentationOptions;
+  /**
+   * The server provides support for mutation test runs.
+   */
+  mutationTestProvider?: MutationTestOptions;
+}
+
+export interface InitializeResult {
+  /**
+   * The capabilities the mutation server provides.
+   */
+  capabilities?: ServerCapabilities;
+
+  /**
+   * The server's information.
+   */
+  serverInfo: {
+    /**
+     * The server's version as defined by the server.
+     */
+    version: string;
+  };
+}
 
 type ProgressToken = number | string;
 
@@ -56,5 +111,5 @@ type MethodsType = Record<string, (params?: any) => any>;
 export interface MutationServerMethods extends MethodsType {
   instrument(params: InstrumentParams): MutantResult[];
   mutate(params: MutateParams): MutantResult[];
-  initialize(params: InitializeParams): typeof InitializeResult;
+  initialize(params: InitializeParams): InitializeResult;
 }

--- a/src/mutation-server/mutation-server-protocol.ts
+++ b/src/mutation-server/mutation-server-protocol.ts
@@ -92,14 +92,14 @@ export interface InstrumentParams {
   globPatterns?: string[];
 }
 
-export interface MutateParams extends PartialResultParams {
+export interface MutationTestParams extends PartialResultParams {
   /**
-   * The glob patterns to mutate.
+   * The glob patterns to mutation test.
    */
   globPatterns?: string[];
 }
 
-export interface MutatePartialResult {
+export interface MutationTestPartialResult {
   /**
    * The mutant results.
    */
@@ -110,6 +110,6 @@ type MethodsType = Record<string, (params?: any) => any>;
 
 export interface MutationServerMethods extends MethodsType {
   instrument(params: InstrumentParams): MutantResult[];
-  mutate(params: MutateParams): MutantResult[];
+  mutationTest(params: MutationTestParams): MutantResult[];
   initialize(params: InitializeParams): InitializeResult;
 }

--- a/src/mutation-server/mutation-server-protocol.ts
+++ b/src/mutation-server/mutation-server-protocol.ts
@@ -47,6 +47,10 @@ export interface ServerCapabilities {
    * The server provides support for mutation test runs.
    */
   mutationTestProvider?: MutationTestOptions;
+  /**
+   * The index signature allows for any number of additional properties,
+   * facilitating the addition of new capabilities in future versions.
+   */
   [key: string]: any;
 }
 

--- a/src/mutation-server/mutation-server-protocol.ts
+++ b/src/mutation-server/mutation-server-protocol.ts
@@ -47,6 +47,7 @@ export interface ServerCapabilities {
    * The server provides support for mutation test runs.
    */
   mutationTestProvider?: MutationTestOptions;
+  [key: string]: any;
 }
 
 export interface InitializeResult {

--- a/src/mutation-server/mutation-server.ts
+++ b/src/mutation-server/mutation-server.ts
@@ -11,8 +11,8 @@ import {
   InitializeParams,
   InitializeResult,
   InstrumentParams,
-  MutateParams,
-  MutatePartialResult,
+  MutationTestParams,
+  MutationTestPartialResult,
   MutationServerMethods,
   ProgressParams,
   ServerCapabilities,
@@ -86,9 +86,9 @@ export class MutationServer {
     );
   }
 
-  public async mutate(
-    params: MutateParams,
-    onPartialResult: (partialResult: MutatePartialResult) => void,
+  public async mutationTest(
+    params: MutationTestParams,
+    onPartialResult: (partialResult: MutationTestPartialResult) => void,
     token?: vscode.CancellationToken,
   ): Promise<void> {
     if (!this.serverCapabilities?.mutationTestProvider?.partialResults) {
@@ -103,7 +103,7 @@ export class MutationServer {
       async () => {
         this.progressNotification$
           .pipe(
-            filter((progress: ProgressParams<MutatePartialResult>) => progress.token === params.partialResultToken),
+            filter((progress: ProgressParams<MutationTestPartialResult>) => progress.token === params.partialResultToken),
             map((progress) => progress.value),
           )
           .subscribe(onPartialResult);
@@ -117,7 +117,7 @@ export class MutationServer {
         await this.rpcClient.requestAdvanced({
           jsonrpc: JSONRPC,
           id: requestId,
-          method: 'mutate',
+          method: 'mutationTest',
           params: params,
         });
       },

--- a/test/unit/handlers/test-controller-handler.spec.ts
+++ b/test/unit/handlers/test-controller-handler.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { TestControllerHandler } from '../../../src/handlers/test-controller-handler';
-import { MutantResult } from '../../api/mutant-result';
+import { MutantResult } from '../../../src/api/mutant-result';
 
 describe('testControllerHandler', () => {
   let controller: vscode.TestController;

--- a/test/unit/mutation-server/mutation-server.spec.ts
+++ b/test/unit/mutation-server/mutation-server.spec.ts
@@ -162,12 +162,12 @@ describe(MutationServer.name, () => {
       expect(receivedMutants.length).to.eq(3);
     });
 
-    it('should throw error if mutation testing with partial results is not supported by the server', async () => {
+    it('should throw error if mutation testing is not supported by the server', async () => {
       // Arrange
-      const sut = new MutationServer(transporterMock, loggerStub, { mutationTestProvider: { partialResults: false } });
+      const sut = new MutationServer(transporterMock, loggerStub, {});
 
       // Act & Assert
-      await expect(sut.mutationTest({}, () => undefined)).to.be.rejectedWith('Mutation tests with partial results are not supported by the server');
+      await expect(sut.mutationTest({}, () => undefined)).to.be.rejectedWith('Mutation testing is not supported by the server');
     });
   });
 

--- a/test/unit/mutation-server/mutation-server.spec.ts
+++ b/test/unit/mutation-server/mutation-server.spec.ts
@@ -11,8 +11,8 @@ import { Logger } from '../../../src/utils/logger';
 import {
   InitializeParams,
   InstrumentParams,
-  MutateParams,
-  MutatePartialResult,
+  MutationTestParams,
+  MutationTestPartialResult,
   ServerCapabilities,
 } from '../../../src/mutation-server/mutation-server-protocol';
 import { MutantResult } from '../../../src/api/mutant-result';
@@ -117,8 +117,8 @@ describe(MutationServer.name, () => {
     });
   });
 
-  describe(MutationServer.prototype.mutate.name, () => {
-    it('should send mutate request and receive partial result', async () => {
+  describe(MutationServer.prototype.mutationTest.name, () => {
+    it('should send mutation test request and receive partial result', async () => {
       // Arrange
       const sendFake = () => {
         transporterMock.emit(
@@ -149,14 +149,14 @@ describe(MutationServer.name, () => {
       sinon.replace(transporterMock, 'send', sinon.fake(sendFake));
 
       const receivedMutants: MutantResult[] = [];
-      const onPartialResult = (partialResult: MutatePartialResult) => {
+      const onPartialResult = (partialResult: MutationTestPartialResult) => {
         receivedMutants.push(...partialResult.mutants);
       };
 
-      const mutateParams: MutateParams = { globPatterns: ['file1', 'file2'], partialResultToken: 1 };
+      const mutationTestParams: MutationTestParams = { globPatterns: ['file1', 'file2'], partialResultToken: 1 };
 
       // Act
-      await mutationServer.mutate(mutateParams, onPartialResult);
+      await mutationServer.mutationTest(mutationTestParams, onPartialResult);
 
       // Assert
       expect(receivedMutants.length).to.eq(3);
@@ -167,7 +167,7 @@ describe(MutationServer.name, () => {
       const sut = new MutationServer(transporterMock, loggerStub, { mutationTestProvider: { partialResults: false } });
 
       // Act & Assert
-      await expect(sut.mutate({}, () => undefined)).to.be.rejectedWith('Mutation tests with partial results are not supported by the server');
+      await expect(sut.mutationTest({}, () => undefined)).to.be.rejectedWith('Mutation tests with partial results are not supported by the server');
     });
   });
 

--- a/test/unit/mutation-server/mutation-server.spec.ts
+++ b/test/unit/mutation-server/mutation-server.spec.ts
@@ -1,14 +1,23 @@
 import EventEmitter from 'events';
 
 import sinon from 'sinon';
-import { expect } from 'chai';
+import { expect, use } from 'chai';
 import { createJSONRPCNotification, createJSONRPCSuccessResponse } from 'json-rpc-2.0';
+import chaiAsPromised from 'chai-as-promised';
 
 import { MutationServer } from '../../../src/mutation-server/mutation-server';
 import { Transporter } from '../../../src/mutation-server/transport/transporter';
 import { Logger } from '../../../src/utils/logger';
-import { InitializeParams, InstrumentParams, MutateParams, MutatePartialResult } from '../../../src/mutation-server/mutation-server-protocol';
+import {
+  InitializeParams,
+  InstrumentParams,
+  MutateParams,
+  MutatePartialResult,
+  ServerCapabilities,
+} from '../../../src/mutation-server/mutation-server-protocol';
 import { MutantResult } from '../../../src/api/mutant-result';
+
+use(chaiAsPromised);
 
 class TransporterMock extends EventEmitter implements Transporter {
   public send() {
@@ -47,101 +56,128 @@ describe(MutationServer.name, () => {
   let transporterMock: TransporterMock;
   let loggerStub: sinon.SinonStubbedInstance<Logger>;
   let mutationServer: MutationServer;
+  let serverCapabilities: ServerCapabilities;
 
   beforeEach(() => {
     transporterMock = new TransporterMock();
     loggerStub = sinon.createStubInstance(Logger);
-    mutationServer = new MutationServer(transporterMock, loggerStub);
+    serverCapabilities = {
+      instrumentationProvider: {
+        partialResults: false,
+      },
+      mutationTestProvider: {
+        partialResults: true,
+      },
+    };
+    mutationServer = new MutationServer(transporterMock, loggerStub, serverCapabilities);
   });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  it('should send instrument request and receive response', async () => {
-    // Arrange
-    const sendFake = () => {
-      transporterMock.emit('message', JSON.stringify(createJSONRPCSuccessResponse(1, [])));
-    };
+  describe(MutationServer.prototype.instrument.name, () => {
+    it('should send instrument request and receive response', async () => {
+      // Arrange
+      const sendFake = () => {
+        transporterMock.emit('message', JSON.stringify(createJSONRPCSuccessResponse(1, [])));
+      };
 
-    sinon.replace(transporterMock, 'send', sinon.fake(sendFake));
+      sinon.replace(transporterMock, 'send', sinon.fake(sendFake));
 
-    const instrumentParams: InstrumentParams = { globPatterns: ['file1', 'file2'] };
-
-    // Act
-    const actualMutantResult = await mutationServer.instrument(instrumentParams);
-
-    // Assert
-    expect(actualMutantResult).to.deep.eq([]);
-  });
-
-  it('should throw and log error when response is not a valid JSON', async () => {
-    // Arrange
-    const sendFake = () => {
-      transporterMock.emit('message', 'invalid JSON');
-    };
-
-    sinon.replace(transporterMock, 'send', sinon.fake(sendFake));
-
-    // Act
-    try {
       const instrumentParams: InstrumentParams = { globPatterns: ['file1', 'file2'] };
-      await mutationServer.instrument(instrumentParams);
-    } catch (error) {
-      // Assert
-      expect(error).to.be.instanceOf(Error);
-    }
 
-    expect(loggerStub.logError.calledOnce).to.be.true;
+      // Act
+      const actualMutantResult = await mutationServer.instrument(instrumentParams);
+
+      // Assert
+      expect(actualMutantResult).to.deep.eq([]);
+    });
+
+    it('should throw and log error when response is not a valid JSON', async () => {
+      // Arrange
+      const sendFake = () => {
+        transporterMock.emit('message', 'invalid JSON');
+      };
+
+      // Act
+      sinon.replace(transporterMock, 'send', sinon.fake(sendFake));
+
+      // Assert
+      await expect(mutationServer.instrument({ globPatterns: ['file1', 'file2'] })).to.be.rejectedWith();
+      expect(loggerStub.logError.calledOnce).to.be.true;
+    });
+
+    it('should throw error if instrumentation is not supported by the server', async () => {
+      // Arrange
+      const sut = new MutationServer(transporterMock, loggerStub, { instrumentationProvider: undefined });
+
+      // Act & Assert
+      await expect(sut.instrument({})).to.be.rejectedWith('Instrumentation is not supported by the server');
+    });
   });
 
-  it('should send mutate request and receive partial result', async () => {
-    // Arrange
-    const sendFake = () => {
-      transporterMock.emit(
-        'message',
-        JSON.stringify(
-          createJSONRPCNotification('progress', {
-            token: 1,
-            value: {
-              mutants: [mutants[0]],
-            },
-          }),
-        ),
-      );
-      transporterMock.emit(
-        'message',
-        JSON.stringify(
-          createJSONRPCNotification('progress', {
-            token: 1,
-            value: {
-              mutants: [mutants[1], mutants[2]],
-            },
-          }),
-        ),
-      );
-      transporterMock.emit('message', JSON.stringify(createJSONRPCSuccessResponse(1, [])));
-    };
+  describe(MutationServer.prototype.mutate.name, () => {
+    it('should send mutate request and receive partial result', async () => {
+      // Arrange
+      const sendFake = () => {
+        transporterMock.emit(
+          'message',
+          JSON.stringify(
+            createJSONRPCNotification('progress', {
+              token: 1,
+              value: {
+                mutants: [mutants[0]],
+              },
+            }),
+          ),
+        );
+        transporterMock.emit(
+          'message',
+          JSON.stringify(
+            createJSONRPCNotification('progress', {
+              token: 1,
+              value: {
+                mutants: [mutants[1], mutants[2]],
+              },
+            }),
+          ),
+        );
+        transporterMock.emit('message', JSON.stringify(createJSONRPCSuccessResponse(1, [])));
+      };
 
-    sinon.replace(transporterMock, 'send', sinon.fake(sendFake));
+      sinon.replace(transporterMock, 'send', sinon.fake(sendFake));
 
-    const receivedMutants: MutantResult[] = [];
-    const onPartialResult = (partialResult: MutatePartialResult) => {
-      receivedMutants.push(...partialResult.mutants);
-    };
+      const receivedMutants: MutantResult[] = [];
+      const onPartialResult = (partialResult: MutatePartialResult) => {
+        receivedMutants.push(...partialResult.mutants);
+      };
 
-    const mutateParams: MutateParams = { globPatterns: ['file1', 'file2'], partialResultToken: 1 };
+      const mutateParams: MutateParams = { globPatterns: ['file1', 'file2'], partialResultToken: 1 };
 
-    // Act
-    await mutationServer.mutate(mutateParams, onPartialResult);
+      // Act
+      await mutationServer.mutate(mutateParams, onPartialResult);
 
-    // Assert
-    expect(receivedMutants.length).to.eq(3);
+      // Assert
+      expect(receivedMutants.length).to.eq(3);
+    });
+
+    it('should throw error if mutation testing with partial results is not supported by the server', async () => {
+      // Arrange
+      const sut = new MutationServer(transporterMock, loggerStub, { mutationTestProvider: { partialResults: false } });
+
+      // Act & Assert
+      await expect(sut.mutate({}, () => undefined)).to.be.rejectedWith('Mutation tests with partial results are not supported by the server');
+    });
   });
 
   describe(MutationServer.prototype.initialize.name, () => {
     it('should send initialize request', async () => {
-      const requestParams: InitializeParams = { configUri: 'configUri' };
+      // Arrange
+      const requestParams: InitializeParams = {
+        clientInfo: { version: '0.0.1' },
+        configUri: 'configUri',
+      };
 
       const fake = sinon.fake(() => {
         transporterMock.emit('message', JSON.stringify(createJSONRPCSuccessResponse(1, [])));


### PR DESCRIPTION
Features:
- Changes to the Mutation Server Protocol (PBI 7340) to support versioning/capabilities handshake.

Refactors:
- Renamed 'mutate' request to 'mutationTest'

Corresponding StrykerJS PR: https://github.com/jaspervdveen/stryker-js/pull/8